### PR TITLE
Don't start both worker and plugin-server on worker service

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,3 +1,3 @@
 FROM posthog/posthog:latest
 
-CMD ["./bin/docker-worker"]
+CMD ["./bin/docker-worker-celery", "--with-scheduler"]


### PR DESCRIPTION
On the worker service only start the celery worker and celery beat services since the plugin server is started under a different service and container.

It's kind of confusing but docker-worker bin starts both
https://github.com/PostHog/posthog/blob/master/bin/docker-worker#L4